### PR TITLE
fix: changed budget range to prevent min == max

### DIFF
--- a/client/src/pages/CreateAccount/CreateAccount.jsx
+++ b/client/src/pages/CreateAccount/CreateAccount.jsx
@@ -89,8 +89,8 @@ const CreateAccount = () => {
         }
 
         // validate budget range
-        if (parseInt(formState.budgetMin) > parseInt(formState.budgetMax)) {
-            setSubmitError('Budget minimum cannot be greater than maximum');
+        if (parseInt(formState.budgetMin) >= parseInt(formState.budgetMax)) {
+            setSubmitError('Budget minimum cannot be greater than or equal to maximum');
             setIsSubmitting(false);
             return;
         }


### PR DESCRIPTION
## Description
This PR is fixing a bug in my create account functionality. Initially, users could have a budget range where the minimum was equal to the maximum. In this PR, I changed the range so that the budget minimum cannot equal the maximum. 

## Milestones
This PR contributes towards finishing the second milestone: create an account. 

## Resources
No additional resources used. 

## Test Plan
I tested this bug fix by inserting a budget range where the minimum was equal to the maximum (e.g. min = 1200 and max = 1200), and I received the updated error explaining that I could not input a budget where the minimum was equal to the maximum. 
