### PR TITLE
fix: defaulted submitError state to null rather than empty string

### DIFF
--- a/client/src/pages/CreateAccount/CreateAccount.jsx
+++ b/client/src/pages/CreateAccount/CreateAccount.jsx
@@ -24,7 +24,7 @@ const CreateAccount = () => {
 
     const [step, setStep] = useState(1);
     const [passwordError, setPasswordError] = useState('');
-    const [submitError, setSubmitError] = useState('');
+    const [submitError, setSubmitError] = useState(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     const createUser = async (userData) => {
@@ -71,7 +71,7 @@ const CreateAccount = () => {
 
     const handleFinalSubmit = async (e) => {
         e.preventDefault();
-        setSubmitError('');
+        setSubmitError(null);
         setIsSubmitting(true);
 
         // error messages for buttons not being selected because no required attribute for buttons

--- a/client/src/pages/Login/Login.jsx
+++ b/client/src/pages/Login/Login.jsx
@@ -5,7 +5,7 @@ import { useUser } from '../../contexts/UserContext';
 
 const Login = () => {
     const [formData, setFormData] = useState({ email: '', password: '' });
-    const [submitError, setSubmitError] = useState('');
+    const [submitError, setSubmitError] = useState(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const { setUser } = useUser();
     const navigate = useNavigate();
@@ -45,7 +45,7 @@ const Login = () => {
 
     const handleSubmit = async (e) => {
         e.preventDefault();
-        setSubmitError('');
+        setSubmitError(null);
         setIsSubmitting(true);
 
         try {

--- a/client/src/pages/RoommateProfileForm/RoommateProfileForm.jsx
+++ b/client/src/pages/RoommateProfileForm/RoommateProfileForm.jsx
@@ -28,7 +28,7 @@ const RoommateProfileForm = () => {
         bio: ''
     });
 
-    const [submitError, setSubmitError] = useState('');
+    const [submitError, setSubmitError] = useState(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     const createRoommateProfile = async (userData) => {
@@ -63,7 +63,7 @@ const RoommateProfileForm = () => {
 
     const handleSubmit = async (e) => {
         e.preventDefault();
-        setSubmitError('');
+        setSubmitError(null);
         setIsSubmitting(true);
 
         // input validation error messages


### PR DESCRIPTION
## Description
- Fixes bug in previous PR (#7) where the submit errors are defaulted to empty strings rather than to null.

## Milestones
This PR does not contribute to one specific milestone, but rather it fixes a bug from a prior PR.

## Resources
No additional resources used.

## Test Plan
To test the application's error handling, I simulated incorrect user inputs and verified that the application handled them. I also then tested correct inputs to ensure that the application still executed correctly. 