### PR TITLE
Paging posts

### DIFF
--- a/client/src/pages/Dashboard/Dashboard.jsx
+++ b/client/src/pages/Dashboard/Dashboard.jsx
@@ -11,10 +11,16 @@ const Dashboard = () => {
   const [error, setError] = useState(null);
   const [userProfile, setUserProfile] = useState("");
   const [showProfileModal, setShowProfileModal] = useState(false);
+  const [nextCursor, setNextCursor] = useState(null);
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const [loading, setLoading] = useState(false);
 
-  const fetchPosts = async () => {
+  const fetchPosts = async (cursor = null, append = false) => {
     try {
-      const response = await fetch("/api/post", {
+      setLoading(true);
+      const url = cursor ? `/api/post?cursor=${cursor}` : "/api/post";
+
+      const response = await fetch(url, {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
@@ -27,12 +33,27 @@ const Dashboard = () => {
         throw new Error(errorInfo.error || "Failed to fetch posts");
       }
 
-      const postsFetched = await response.json();
-      setPosts(postsFetched);
-      await fetchAllProfilePictures(postsFetched);
+      const { posts: postsFetched, nextCursor: newCursor, hasNextPage: hasMore } = await response.json();
+
+      if (append) {
+        setPosts(prevPosts => [...prevPosts, ...postsFetched]);
+      } else {
+        setPosts(postsFetched);
+      }
+
+      setNextCursor(newCursor);
+      setHasNextPage(hasMore);
       setError(null);
     } catch (error) {
       setError(error.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadMorePosts = () => {
+    if (nextCursor && hasNextPage && !loading) {
+      fetchPosts(nextCursor, true);
     }
   };
 
@@ -103,6 +124,16 @@ const Dashboard = () => {
           ))
         )}
       </div>
+
+      {hasNextPage && (
+        <button
+          className="btn-primary"
+          onClick={loadMorePosts}
+          disabled={loading}
+        >
+          {loading ? "Loading..." : "Load More"}
+        </button>
+      )}
 
       {showProfileModal && (
         <ProfileModal

--- a/client/src/pages/Dashboard/Dashboard.jsx
+++ b/client/src/pages/Dashboard/Dashboard.jsx
@@ -34,10 +34,14 @@ const Dashboard = () => {
         throw new Error(errorInfo.error || "Failed to fetch posts");
       }
 
-      const { posts: postsFetched, nextCursor: newCursor, hasNextPage: hasMore } = await response.json();
+      const {
+        posts: postsFetched,
+        nextCursor: newCursor,
+        hasNextPage: hasMore,
+      } = await response.json();
 
       if (append) {
-        setPosts(prevPosts => [...prevPosts, ...postsFetched]);
+        setPosts((prevPosts) => [...prevPosts, ...postsFetched]);
       } else {
         setPosts(postsFetched);
       }

--- a/server/api/posts.js
+++ b/server/api/posts.js
@@ -54,6 +54,8 @@ router.get("/", async (req, res) => {
         .json({ error: "You must be logged in to view other user's posts." });
     }
 
+    const cursor = req.query.cursor ? parseInt(req.query.cursor) : 0;
+
     const currentUserProfile = await prisma.roommateProfile.findUnique({
       where: { user_id: req.session.userId },
       select: { city: true, state: true },
@@ -74,6 +76,13 @@ router.get("/", async (req, res) => {
             id: "desc",
           },
         ],
+        take: 21,
+        ...(cursor && {
+          cursor: {
+            id: cursor,
+          },
+          skip: 1,
+        }),
       });
     } else {
       // use mode: "insensitive" to match locations without case sensitivity
@@ -97,10 +106,28 @@ router.get("/", async (req, res) => {
             id: "desc",
           },
         ],
+        take: 21,
+        ...(cursor && {
+          cursor: {
+            id: cursor,
+          },
+          skip: 1,
+        }),
       });
     }
 
-    res.status(200).json(posts);
+    const hasNextPage = posts.length > 20;
+    if (hasNextPage) {
+      posts.pop();
+    }
+
+    const nextCursor = hasNextPage ? posts[posts.length - 1].id : null;
+
+    res.status(200).json({
+      posts,
+      nextCursor,
+      hasNextPage,
+    });
   } catch (err) {
     res.status(500).json("Error getting posts");
   }


### PR DESCRIPTION
## Description
- Changed backend GET all posts route to implement paging of posts where users are only able to retrieve 20 posts at a time. 
- Implemented a load more button on the frontend to fetch the posts using paging. 
- If less than 20 posts are available to the user, there is no load more button available. Otherwise, the load more button appears and the user is able to press it and more posts populate on the screen.

## Milestones
This PR contributes towards completing milestone 13: users can press load more button and more posts are loaded. 

## Resources
https://www.prisma.io/docs/orm/prisma-client/queries/pagination 

## Test Plan
<img width="1728" alt="Screenshot 2025-07-09 at 2 59 15 PM" src="https://github.com/user-attachments/assets/1bbb3d3e-09c8-4a1d-bb55-dc505205b0d6" />
<img width="1728" alt="Screenshot 2025-07-09 at 2 59 40 PM" src="https://github.com/user-attachments/assets/c7588a19-1cbd-40f3-ae49-66318e340120" />
<img width="1728" alt="Screenshot 2025-07-09 at 2 59 58 PM" src="https://github.com/user-attachments/assets/87de4a7c-ec45-4697-a422-efe73ac462cd" />
