### PR TITLE
fix: added number of roommates distance calculation to compute similarity in KNN

### DIFF
--- a/server/utils/RecommendationEngine.js
+++ b/server/utils/RecommendationEngine.js
@@ -104,6 +104,9 @@ class RecommendationEngine {
       roomType:
         1 /
         (1 + distanceBetweenEnumValues("roomType", a.room_type, b.room_type)),
+      numRoommates:
+        1 /
+        (1 + distanceBetweenNumericalValues(a.num_roommates, b.num_roommates)),
       sleepSchedule:
         1 /
         (1 +


### PR DESCRIPTION
## Description
This PR fixes a bug found within my first iteration of K-Nearest Neighbors. To improve on my first iteration, I calculated the similarity between the number of roommates the user input that they are looking for, which contributes to the overall similarity score after adding the weighted sums of each field's similarity score and dividing by the total weight. 

## Milestones
This PR refines milestone 20: implement KNN. 

## Resources
No additional resources used. 

## Test Plan
I tested that this update to my KNN works by using Insomnia to test my get all matches endpoint, and observing how the similarity scores and recommended users adjusted for one specific user after implementing this change. 
