### PR TITLE
feat: iterated on KNN to exclude previously rejected users from recommendations

### DIFF
--- a/server/api/matches.js
+++ b/server/api/matches.js
@@ -39,7 +39,7 @@ router.get("/", async (req, res) => {
       others,
       otherUsers,
     );
-    const results = recommender.getTopKRecommendations(20);
+    const results = await recommender.getTopKRecommendations(20);
 
     res.status(200).json(results);
   } catch (err) {


### PR DESCRIPTION
## Description
Filtered KNN recommendations so that previously rejected users are not recommended to the same user again. This is done by checking if there is a negative match status between a pair of users. If there is, these two users will not be recommended to each other again.

## Milestones
This PR contributes towards refining milestone 20: implement KNN.

## Resources
No additional resources used. 

## Test Plan
I tested that this works by using Insomnia to test my GET /matches and PUT /matches endpoints. I logged in a user, fetched recommendations for that user, and sent a friend request to one of the recommended users. I logged in as the user who received the friend request, rejected the request, and then refetched all match recommendations for both users and ensured that they did not reappear as recommendations for each other.