### PR TITLE
feat: implemented filtering rejected groups and changing match status based on group formations

### DIFF
--- a/server/prisma/migrations/20250717185420_added_group_model/migration.sql
+++ b/server/prisma/migrations/20250717185420_added_group_model/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "group_id" DROP NOT NULL,
+ALTER COLUMN "group_id" DROP DEFAULT;
+
+-- CreateTable
+CREATE TABLE "Group" (
+    "id" SERIAL NOT NULL,
+
+    CONSTRAINT "Group_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "User" ADD CONSTRAINT "User_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "Group"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/prisma/migrations/20250717225020_added_potential_group_id_to_match/migration.sql
+++ b/server/prisma/migrations/20250717225020_added_potential_group_id_to_match/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Matches" ADD COLUMN     "potential_group_id" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -89,12 +89,14 @@ model User {
   office_address                  String
   office_latitude                 Float?
   office_longitude                Float?
-  group_id                        Int               @default(0)
+  group                           Group?            @relation(fields: [group_id], references: [id])
+  group_id                        Int?
   roommate_profile                RoommateProfile?
   posts                           Post[]
   received_matches                Matches[]         @relation("ReceivedMatches")
   recommended_matches             Matches[]         @relation("RecommendedMatches")
   sent_friend_requests            Matches[]         @relation("SentFriendRequests")
+
 }
 
 model RoommateProfile {
@@ -156,10 +158,16 @@ model Matches {
   recommended_id            Int
   similarity_score          Float
   status                    MatchStatus      @default(PENDING)
+  potential_group_id        String?
   friend_request_sent_by    Int?
   friend_request_sender     User?            @relation("SentFriendRequests", fields: [friend_request_sent_by], references: [id])
   friend_request_sent_at    DateTime?
   responded_at              DateTime?
   created_at                DateTime         @default(now())
   updated_at                DateTime         @updatedAt
+}
+
+model Group {
+  id                        Int              @id @default(autoincrement())
+  members                   User[]
 }


### PR DESCRIPTION
## Description
- Implemented filtering of multiple group options based on if a user had already rejected a request or recommendation to join the group.
- Adjusted API endpoints for matches to incorporate matching based on groups.
- Users are now able to send friend requests to individual users, or specify a group that they would like to send a request to. Automatically, this group is iterated through and friend requests are sent to all members of the group. However, each individual member is able to accept or reject the request. 
- If a user chooses to send an individual friend request, they are able to continue adding to their roommate pod.
- Users are not able to join multiple roommate pods at once.
- Users are able to leave a roommate pod, and if a roommate pod has less than 2 users within it, this group gets dissolved. 

## Milestones
This PR contributes to completing the backend of milestones 22 - 25.

- Milestone 22: User can send roommate request  or reject roommate suggestion on recommendations page.
- Milestone 23: User can press match me on recommendations page and be suggested a list of users based on preferences.
- Milestone 24: User can accept or reject roommate request.
- Milestone 25: User can match with multiple users to form a roommate pod.

## Resources
No additional resources used.

## Test Plan
I tested each of these individual endpoints in Insomnia, accounting for various edge cases. Below I have provided a list of steps I used to test that the endpoints worked: 

- Logged in a user.
- Viewed group recommendations.
- Sent request to a group recommended.
- Logged in as each individual user that received a friend request as part of the group request.
- Fetched friend requests for each user, and had some users update the match status to reject the request while others accepted the request.
- Tested the GET /matches/accepted endpoint to check that the output was correct.
- Verified within the database that the correct group was formed.
- Tested the DELETE /matches/leave endpoint to have a user leave the group, and checked the database to ensure this user was removed from the group.

Additionally, I tested different edge cases, such as: 
- User tries to join another roommate pod.
- Fetched group recommendations for rejected recommendations and checked that rejected recommendations did not reappear.

I ensured that each status response was 200, and that my database reflected the correct changes within groups to ensure the accuracy of my PR. 
