### PR TITLE
feat: resolved leaving pod bugs and added close group functionality

### DIFF
--- a/client/src/pages/RoommatePod/RoomatePod.css
+++ b/client/src/pages/RoommatePod/RoomatePod.css
@@ -4,13 +4,13 @@
   margin: 0 auto;
 }
 
-.leave-pod-button {
+.pod-buttons {
   display: flex;
   justify-content: flex-end;
   margin-bottom: 15px;
 }
 
-.leave-pod-button button {
+.pod-buttons button {
   background-color: rgb(254, 162, 162);
   color: rgb(219, 9, 9);
   font-weight: bold;
@@ -21,6 +21,7 @@
   transition:
     background-color 0.3s,
     transform 0.2s;
+  margin: 0 5px;
 }
 
 .leave-pod-button button:hover {

--- a/server/prisma/migrations/20250721001919_added_group_status_field/migration.sql
+++ b/server/prisma/migrations/20250721001919_added_group_status_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Group" ADD COLUMN     "group_status" TEXT;

--- a/server/prisma/migrations/20250721002131_added_default_open_status_to_groups/migration.sql
+++ b/server/prisma/migrations/20250721002131_added_default_open_status_to_groups/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Group" ALTER COLUMN "group_status" SET DEFAULT 'OPEN';

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -172,4 +172,5 @@ model Matches {
 model Group {
   id                        Int              @id @default(autoincrement())
   members                   User[]
+  group_status              String?          @default("OPEN")
 }

--- a/server/utils/RecommendationEngine.js
+++ b/server/utils/RecommendationEngine.js
@@ -292,7 +292,7 @@ class RecommendationEngine {
       };
     });
 
-    // exclude recommendations who have already been rejected by the user
+    // exclude recommendations who have already been rejected by the user or are in closed groups
     const filteredRecommendations = [];
     for (const rec of recommendations) {
       // check match model for existing negative match status
@@ -313,7 +313,18 @@ class RecommendationEngine {
         },
       });
 
-      if (!existingNegativeMatch) {
+      // check if user is in a closed group
+      const userInClosedGroup = await prisma.user.findFirst({
+        where: {
+          id: rec.user_id,
+          group: {
+            group_status: "CLOSED",
+          },
+        },
+      });
+
+      // only add recommendation if user is not in a closed group and there's no negative match
+      if (!existingNegativeMatch && !userInClosedGroup) {
         filteredRecommendations.push(rec);
       }
     }


### PR DESCRIPTION
## Description

- Made the leave pod button only active and available to the user if they have currently have a roommate pod.
- Resolved bug with groups not deleting in database if they contained less than 2 users.
- Added a group status field to the Group model to indicate if the group is open or closed to new roommates.
- Implemented API endpoint to update the group status.
- Added a "Close/Open Pod" button to the roommate pod page so that users can update the status of their group.
- Implemented validation within API endpoints to ensure that users cannot send a friend request if their current group is closed. 
- Filtered individual and group recommendations to exclude users that are within a closed group.

## Milestones
This PR refines the milestones associated with viewing recommendations, sending roommate requests, and viewing the roommate pod. 

## Resources
No additional resources used.

## Test Plan
<img width="1728" height="902" alt="Screenshot 2025-07-20 at 5 57 56 PM" src="https://github.com/user-attachments/assets/7a9137ed-ed58-4240-83dd-ecbccbf07a13" />
<img width="1728" height="863" alt="Screenshot 2025-07-20 at 5 58 13 PM" src="https://github.com/user-attachments/assets/387067c0-3add-4174-af9b-668514105fa2" />
