### PR TITLE
fix: enhanced create account UI to display email and password input restrictions

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -431,7 +431,19 @@ body {
 }
 
 .form-input {
-  @apply w-full p-4 border-2 border-gray-300 rounded-lg text-base transition-all bg-white text-black focus:outline-none focus:border-[#3066BE] focus:ring-2 focus:ring-[#3066BE]/20 hover:border-gray-400;
+  @apply w-full p-4 border-2 border-gray-300 rounded-lg text-base transition-all bg-white text-black focus:outline-none focus:border-[#3066BE] focus:ring-2 focus:ring-[#3066BE]/20;
+}
+
+.valid-input {
+  @apply border-green-500;
+}
+
+.input-container {
+  @apply relative;
+}
+
+.validation-icon {
+  @apply absolute right-3 top-1/2 transform -translate-y-1/2 text-green-500 text-base;
 }
 
 .form-textarea {

--- a/client/src/pages/CreateAccount/CreateAccount.jsx
+++ b/client/src/pages/CreateAccount/CreateAccount.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Spinner from "../../components/Spinner/Spinner";
 
@@ -33,9 +33,12 @@ const CreateAccount = () => {
   });
 
   const [step, setStep] = useState(1);
-  const [passwordError, setPasswordError] = useState("");
+  const [accountDetailsError, setAccountDetailsError] = useState("");
   const [submitError, setSubmitError] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isEmailValid, setIsEmailValid] = useState(false);
+  const [isPasswordValid, setIsPasswordValid] = useState(false);
+  const [doPasswordsMatch, setDoPasswordsMatch] = useState(false);
 
   const createUser = async (userData) => {
     try {
@@ -66,15 +69,51 @@ const CreateAccount = () => {
     }));
   };
 
+  useEffect(() => {
+    const emailIsValid =
+      formState.email.includes("@") && formState.email.endsWith(".edu");
+    setIsEmailValid(emailIsValid);
+
+    const passwordIsValid = formState.password.length >= 8;
+    setIsPasswordValid(passwordIsValid);
+
+    const passwordsMatch =
+      formState.password &&
+      formState.confirmPassword &&
+      formState.password === formState.confirmPassword;
+    setDoPasswordsMatch(passwordsMatch);
+  }, [formState.email, formState.password, formState.confirmPassword]);
+
   const handleFirstStepSubmit = (e) => {
     e.preventDefault();
 
-    if (formState.password !== formState.confirmPassword) {
-      setPasswordError("Passwords do not match");
+    // basic user account details validation
+    const validationChecks = [
+      { condition: !formState.email, message: "Email is required." },
+      { condition: !formState.password, message: "Password is required." },
+      {
+        condition: !formState.confirmPassword,
+        message: "Please confirm your password.",
+      },
+      {
+        condition: !isEmailValid,
+        message: "Email must be a valid .edu address.",
+      },
+      {
+        condition: !isPasswordValid,
+        message: "Password must be at least 8 characters.",
+      },
+      { condition: !doPasswordsMatch, message: "Passwords do not match." },
+    ];
+
+    const error = validationChecks.find((check) => check.condition);
+
+    if (error) {
+      setAccountDetailsError(error.message);
       return;
     }
 
-    setPasswordError("");
+    setAccountDetailsError("");
     setStep(2);
   };
 
@@ -210,48 +249,68 @@ const CreateAccount = () => {
                 <label className="form-label" htmlFor="email">
                   Email
                 </label>
-                <input
-                  className="form-input"
-                  type="email"
-                  id="email"
-                  value={formState.email}
-                  onChange={(e) => updateFormField("email", e.target.value)}
-                  required
-                />
+                <div className="input-container">
+                  <input
+                    className={`form-input ${isEmailValid && formState.email ? "valid-input" : ""}`}
+                    type="email"
+                    id="email"
+                    placeholder="Must end with .edu"
+                    value={formState.email}
+                    onChange={(e) => updateFormField("email", e.target.value)}
+                    required
+                  />
+                  {isEmailValid && formState.email && (
+                    <span className="validation-icon">&#x2713;</span>
+                  )}
+                </div>
               </div>
 
               <div className="form-group">
                 <label className="form-label" htmlFor="password">
                   Password
                 </label>
-                <input
-                  className="form-input"
-                  type="password"
-                  id="password"
-                  value={formState.password}
-                  onChange={(e) => updateFormField("password", e.target.value)}
-                  required
-                />
+                <div className="input-container">
+                  <input
+                    className={`form-input ${isPasswordValid && formState.password ? "valid-input" : ""}`}
+                    type="password"
+                    id="password"
+                    placeholder="Must be at least 8 characters"
+                    value={formState.password}
+                    onChange={(e) =>
+                      updateFormField("password", e.target.value)
+                    }
+                    required
+                  />
+                  {isPasswordValid && formState.password && (
+                    <span className="validation-icon">&#x2713;</span>
+                  )}
+                </div>
               </div>
 
               <div className="form-group">
                 <label className="form-label" htmlFor="confirmPassword">
                   Confirm Password
                 </label>
-                <input
-                  className="form-input"
-                  type="password"
-                  id="confirmPassword"
-                  value={formState.confirmPassword}
-                  onChange={(e) =>
-                    updateFormField("confirmPassword", e.target.value)
-                  }
-                  required
-                />
+                <div className="input-container">
+                  <input
+                    className={`form-input ${doPasswordsMatch ? "valid-input" : ""}`}
+                    type="password"
+                    id="confirmPassword"
+                    placeholder="Must match password"
+                    value={formState.confirmPassword}
+                    onChange={(e) =>
+                      updateFormField("confirmPassword", e.target.value)
+                    }
+                    required
+                  />
+                  {doPasswordsMatch && (
+                    <span className="validation-icon">&#x2713;</span>
+                  )}
+                </div>
               </div>
 
-              {passwordError && (
-                <div className="error-message">{passwordError}</div>
+              {accountDetailsError && (
+                <div className="error-message">{accountDetailsError}</div>
               )}
               <button type="submit" className="btn-primary">
                 Continue


### PR DESCRIPTION
## Description

- Improved the UI so that when a user creates an account, they can view the email and password requirements for proper account creation.
- Added green border and check mark to validate user input on account creation. 

## Milestones
This PR contributes to refining the create account milestone. 

## Resources
[Link that provided unicode hex for check mark](https://www.alt-codes.net/check-mark-symbols.php)

## Test Plan
<img width="655" height="711" alt="Screenshot 2025-07-21 at 12 27 08 PM" src="https://github.com/user-attachments/assets/e47647f1-30e9-44a9-9e77-8de13774009d" />
<img width="755" height="750" alt="Screenshot 2025-07-21 at 12 27 24 PM" src="https://github.com/user-attachments/assets/444fdae5-39bc-49b4-aa10-54d1a7eafafe" />
