### PR TITLE
feat: refactored roommate pod to create roommate card component and match pod btn styling with recommendations btns

### DIFF
--- a/client/src/components/RoommateCard/RoommateCard.css
+++ b/client/src/components/RoommateCard/RoommateCard.css
@@ -1,0 +1,136 @@
+/* Card base styles */
+.roommate-card {
+  width: 280px;
+  height: 400px;
+  perspective: 1000px;
+  cursor: pointer;
+  border-radius: 10px;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
+}
+
+.roommate-card:hover {
+  transform: translateY(-5px);
+}
+
+/* Card inner container for flip effect */
+.roommate-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.8s;
+  transform-style: preserve-3d;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  border-radius: 10px;
+  transform-origin: center center;
+}
+
+/* Flip the card when the flipped class is added */
+.roommate-card.flipped .roommate-card-inner {
+  transform: rotateY(180deg);
+}
+
+/* Position the front and back sides */
+.roommate-card-front,
+.roommate-card-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  border-radius: 10px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 15px;
+  box-sizing: border-box;
+}
+
+.roommate-card-front {
+  background-color: white;
+  z-index: 2;
+}
+
+.roommate-card-front h2 {
+  margin-top: 10px;
+  font-size: 1.5rem;
+  color: #3066be;
+  text-shadow: #3e6b90 1px 0 1px;
+}
+
+.roommate-card-image {
+  width: 100%;
+  height: 250px;
+  overflow: hidden;
+  border-radius: 5px;
+  margin-bottom: 15px;
+}
+
+.roommate-card-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+.roommate-card:hover .roommate-card-image img {
+  transform: scale(1.05);
+}
+
+/* Back side styling */
+.roommate-card-back {
+  background-color: #f8f8f8;
+  transform: rotateY(180deg);
+  justify-content: space-between;
+  text-align: left;
+  z-index: 1;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.roommate-card-back h3 {
+  width: 100%;
+  text-align: center;
+  margin-bottom: 15px;
+  font-size: 1.5rem;
+  color: #3066be;
+  text-shadow: #3e6b90 1px 0 1px;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 10px;
+}
+
+.roommate-info {
+  width: 100%;
+  overflow-y: auto;
+  flex-grow: 1;
+}
+
+.roommate-info p {
+  margin: 8px 0;
+  font-size: 0.9rem;
+  padding-left: 5px;
+  border-left: #3066be solid 2px;
+  padding-bottom: 5px;
+}
+
+.roommate-info p strong {
+  font-weight: bold;
+  color: #3066be;
+}
+
+.view-profile-btn {
+  background-color: #3066be;
+  color: white;
+  border: none;
+  padding: 10px 15px;
+  border-radius: 5px;
+  cursor: pointer;
+  margin-top: 15px;
+  font-weight: bold;
+  transition: background-color 0.3s;
+}
+
+.view-profile-btn:hover {
+  background-color: #6d9dc5;
+}

--- a/client/src/components/RoommateCard/RoommateCard.jsx
+++ b/client/src/components/RoommateCard/RoommateCard.jsx
@@ -1,0 +1,95 @@
+import fallbackProfilePic from "../../assets/fallback-profile-picture.png";
+import "./RoommateCard.css";
+
+const RoommateCard = ({
+  member,
+  isFlipped,
+  onCardFlip,
+  onViewProfile,
+  onMouseMove,
+  onMouseLeave,
+  onButtonHover,
+}) => {
+  return (
+    <div
+      className={`roommate-card ${isFlipped ? "flipped" : ""}`}
+      onClick={() => onCardFlip(member.id)}
+      onMouseMove={onMouseMove}
+      onMouseLeave={onMouseLeave}
+    >
+      <div className="roommate-card-inner">
+        <div className="roommate-card-front">
+          <div className="roommate-card-image">
+            <img
+              src={`/api/roommate-profile/profile-picture/${member.id}`}
+              alt={`${member.name}'s profile`}
+              onError={(e) => {
+                e.target.src = fallbackProfilePic;
+              }}
+            />
+          </div>
+          <h2>{member.name}</h2>
+        </div>
+
+        <div className="roommate-card-back">
+          <h3>{member.name}</h3>
+          <div className="roommate-info">
+            <p>
+              <strong>Email:</strong> {member.email}
+            </p>
+            {member.phone_number && (
+              <p>
+                <strong>Phone:</strong> {member.phone_number}
+              </p>
+            )}
+            {member.instagram_handle && (
+              <p>
+                <strong>Instagram:</strong> {member.instagram_handle}
+              </p>
+            )}
+            {member.company && (
+              <p>
+                <strong>Company:</strong> {member.company}
+              </p>
+            )}
+            {member.university && (
+              <p>
+                <strong>University:</strong> {member.university}
+              </p>
+            )}
+            {member.office_address && (
+              <p>
+                <strong>Office:</strong> {member.office_address}
+              </p>
+            )}
+            {member.roommate_profile.city && (
+              <p>
+                <strong>Location:</strong> {member.roommate_profile.city},{" "}
+                {member.roommate_profile.state}
+              </p>
+            )}
+          </div>
+          <button
+            className="view-profile-btn"
+            onClick={(e) => {
+              e.stopPropagation();
+              onViewProfile(member);
+            }}
+            onMouseEnter={(e) => {
+              e.stopPropagation();
+              onButtonHover(true);
+            }}
+            onMouseLeave={(e) => {
+              e.stopPropagation();
+              onButtonHover(false);
+            }}
+          >
+            View Full Profile
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RoommateCard;

--- a/client/src/pages/RoommatePod/RoomatePod.css
+++ b/client/src/pages/RoommatePod/RoomatePod.css
@@ -5,27 +5,35 @@
 }
 
 .pod-buttons {
+  flex: 1;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
   display: flex;
-  justify-content: flex-end;
-  margin-bottom: 15px;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  transition: all 0.2s;
+  opacity: 1;
 }
 
 .pod-buttons button {
-  background-color: rgb(254, 162, 162);
-  color: rgb(219, 9, 9);
-  font-weight: bold;
-  border: none;
-  border-radius: 5px;
-  padding: 10px 15px;
-  cursor: pointer;
-  transition:
-    background-color 0.3s,
-    transform 0.2s;
-  margin: 0 5px;
+  flex: 1;
+  color: #dc2626;
+  font-size: 14px;
+  background-color: #fef2f2;
+  border-radius: 8px;
+  padding: 16px 24px;
+  max-width: 400px;
 }
 
-.leave-pod-button button:hover {
-  background-color: rgb(255, 130, 130);
+.pod-buttons button:hover {
+  background-color: #fee2e2;
   transform: translateY(-2px);
 }
 
@@ -43,143 +51,6 @@
   border: #3066be solid 4px;
   border-radius: 10px;
   padding: 20px;
-}
-
-/* Card base styles */
-.roommate-card {
-  width: 280px;
-  height: 400px;
-  perspective: 1000px;
-  cursor: pointer;
-  border-radius: 10px;
-  transition:
-    transform 0.3s ease,
-    box-shadow 0.3s ease;
-}
-
-.roommate-card:hover {
-  transform: translateY(-5px);
-}
-
-/* Card inner container for flip effect */
-.roommate-card-inner {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  transition: transform 0.8s;
-  transform-style: preserve-3d;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  border-radius: 10px;
-  transform-origin: center center;
-}
-
-/* Flip the card when the flipped class is added */
-.roommate-card.flipped .roommate-card-inner {
-  transform: rotateY(180deg);
-}
-
-/* Position the front and back sides */
-.roommate-card-front,
-.roommate-card-back {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  -webkit-backface-visibility: hidden;
-  backface-visibility: hidden;
-  border-radius: 10px;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 15px;
-  box-sizing: border-box;
-}
-
-.roommate-card-front {
-  background-color: white;
-  z-index: 2;
-}
-
-.roommate-card-front h2 {
-  margin-top: 10px;
-  font-size: 1.5rem;
-  color: #3066be;
-  text-shadow: #3e6b90 1px 0 1px;
-}
-
-.roommate-card-image {
-  width: 100%;
-  height: 250px;
-  overflow: hidden;
-  border-radius: 5px;
-  margin-bottom: 15px;
-}
-
-.roommate-card-image img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: transform 0.3s ease;
-}
-
-.roommate-card:hover .roommate-card-image img {
-  transform: scale(1.05);
-}
-
-/* Back side styling */
-.roommate-card-back {
-  background-color: #f8f8f8;
-  transform: rotateY(180deg);
-  justify-content: space-between;
-  text-align: left;
-  z-index: 1;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-}
-
-.roommate-card-back h3 {
-  width: 100%;
-  text-align: center;
-  margin-bottom: 15px;
-  font-size: 1.5rem;
-  color: #3066be;
-  text-shadow: #3e6b90 1px 0 1px;
-  border-bottom: 1px solid #ddd;
-  padding-bottom: 10px;
-}
-
-.roommate-info {
-  width: 100%;
-  overflow-y: auto;
-  flex-grow: 1;
-}
-
-.roommate-info p {
-  margin: 8px 0;
-  font-size: 0.9rem;
-  padding-left: 5px;
-  border-left: #3066be solid 2px;
-  padding-bottom: 5px;
-}
-
-.roommate-info p strong {
-  font-weight: bold;
-  color: #3066be;
-}
-
-.view-profile-btn {
-  background-color: #3066be;
-  color: white;
-  border: none;
-  padding: 10px 15px;
-  border-radius: 5px;
-  cursor: pointer;
-  margin-top: 15px;
-  font-weight: bold;
-  transition: background-color 0.3s;
-}
-
-.view-profile-btn:hover {
-  background-color: #6d9dc5;
 }
 
 /* Custom tooltip styles */
@@ -219,8 +90,6 @@
     opacity: 1;
   }
 }
-
-/* Error message */
 .error-message {
   color: #d9534f;
   text-align: center;
@@ -230,7 +99,6 @@
   border-radius: 5px;
 }
 
-/* Responsive adjustments */
 @media (max-width: 768px) {
   .roommate-card {
     width: 250px;

--- a/client/src/pages/RoommatePod/RoommatePod.jsx
+++ b/client/src/pages/RoommatePod/RoommatePod.jsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import Spinner from "../../components/Spinner/Spinner";
-import fallbackProfilePic from "../../assets/fallback-profile-picture.png";
 import ProfileModal from "../../components/ProfileModal/ProfileModal";
+import RoommateCard from "../../components/RoommateCard/RoommateCard";
 import WithAuth from "../../components/WithAuth/WithAuth";
 import { useNavigate } from "react-router-dom";
 import "./RoomatePod.css";
@@ -139,6 +139,7 @@ const RoommatePod = () => {
       profile: member.roommate_profile,
     };
     setActiveProfile(profileData);
+    setShowTooltip(false);
   };
 
   const closeProfileModal = () => {
@@ -155,15 +156,6 @@ const RoommatePod = () => {
     <div className="roommate-pod-container">
       <h1 className="pod-title">Roommate Pod</h1>
 
-      {pod && pod.length > 0 && (
-        <div className="pod-buttons">
-          <button onClick={handleUpdateGroupStatus}>
-            {groupClosed ? "Open Pod" : "Close Pod"}
-          </button>
-          <button onClick={handleLeaveRoommatePod}>Leave Pod</button>
-        </div>
-      )}
-
       <div className="roommate-cards-container">
         {error && <div className="error-message">{String(error)}</div>}
 
@@ -176,10 +168,12 @@ const RoommatePod = () => {
 
         {pod &&
           pod.map((member) => (
-            <div
+            <RoommateCard
               key={member.id}
-              className={`roommate-card ${flippedCards[member.id] ? "flipped" : ""}`}
-              onClick={() => handleCardFlip(member.id)}
+              member={member}
+              isFlipped={flippedCards[member.id]}
+              onCardFlip={handleCardFlip}
+              onViewProfile={openProfileModal}
               onMouseMove={(e) => {
                 // get the position relative to the viewport
                 // reference for mouse tracking: https://medium.com/@ryan_forrester_/how-to-get-mouse-position-in-javascript-37e4772a3f21
@@ -197,78 +191,23 @@ const RoommatePod = () => {
               onMouseLeave={() => {
                 setShowTooltip(false);
               }}
-            >
-              <div className="roommate-card-inner">
-                <div className="roommate-card-front">
-                  <div className="roommate-card-image">
-                    <img
-                      src={`/api/roommate-profile/profile-picture/${member.id}`}
-                      alt={`${member.name}'s profile`}
-                      onError={(e) => {
-                        e.target.src = fallbackProfilePic;
-                      }}
-                    />
-                  </div>
-                  <h2>{member.name}</h2>
-                </div>
-
-                <div className="roommate-card-back">
-                  <h3>{member.name}</h3>
-                  <div className="roommate-info">
-                    <p>
-                      <strong>Email:</strong> {member.email}
-                    </p>
-                    {member.phone_number && (
-                      <p>
-                        <strong>Phone:</strong> {member.phone_number}
-                      </p>
-                    )}
-                    {member.instagram_handle && (
-                      <p>
-                        <strong>Instagram:</strong> {member.instagram_handle}
-                      </p>
-                    )}
-                    {member.company && (
-                      <p>
-                        <strong>Company:</strong> {member.company}
-                      </p>
-                    )}
-                    {member.university && (
-                      <p>
-                        <strong>University:</strong> {member.university}
-                      </p>
-                    )}
-                    {member.office_address && (
-                      <p>
-                        <strong>Office:</strong> {member.office_address}
-                      </p>
-                    )}
-                    {member.roommate_profile.city && (
-                      <p>
-                        <strong>Location:</strong>{" "}
-                        {member.roommate_profile.city},{" "}
-                        {member.roommate_profile.state}
-                      </p>
-                    )}
-                  </div>
-                  <button
-                    className="view-profile-btn"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      openProfileModal(member);
-                    }}
-                    onMouseEnter={() => setIsOverButton(true)}
-                    onMouseLeave={() => setIsOverButton(false)}
-                  >
-                    View Full Profile
-                  </button>
-                </div>
-              </div>
-            </div>
+              onButtonHover={(isOver) => {
+                setIsOverButton(isOver);
+              }}
+            />
           ))}
       </div>
 
-      {/* hides tooltip when hovering over view profile button*/}
+      {pod && pod.length > 0 && (
+        <div className="pod-buttons">
+          <button onClick={handleUpdateGroupStatus}>
+            {groupClosed ? "Open Pod" : "Close Pod"}
+          </button>
+          <button onClick={handleLeaveRoommatePod}>Leave Pod</button>
+        </div>
+      )}
+
+      {/* hides tooltip when hovering over view profile button */}
       {showTooltip && !isOverButton && (
         <div
           className="cursor-tooltip"


### PR DESCRIPTION
## Description

- Refactored the roommate pod code to create a Roommate Card component to separate the custom visual styling component for easier readability.
- Changed the positioning of the leave pod and close/open pod buttons to the bottom of the roommate pod container, similar to that of the recommendations page. 
- Improved the styling of the pod buttons to more closely resemble that of the recommendations page. 

## Milestones
This PR contributes to refining the roommate pod page through refactoring. 

## Resources
[GitHub repository that matches Tailwind colors with their hex values](https://github.com/15fathoms/tailwind-colors/blob/main/css/colors-hex.css)

## Test Plan

Roommate pod buttons:
<img width="989" height="684" alt="Screenshot 2025-07-22 at 12 21 55 PM" src="https://github.com/user-attachments/assets/902e6fec-e3d7-4d9c-b190-9ca6083d4f26" />

Recommendations action buttons: 
<img width="1176" height="347" alt="Screenshot 2025-07-22 at 12 22 07 PM" src="https://github.com/user-attachments/assets/b5ee021a-5c3d-48eb-84fa-0b99dd8dcb9a" />
