### PR TITLE
fix: set cross origin header for genAI bio API call

### DIFF
--- a/server/api/roommateProfile.js
+++ b/server/api/roommateProfile.js
@@ -436,6 +436,8 @@ router.put("/bio/:id", async (req, res) => {
       bio: generatedBio,
       profile: updatedProfile,
     });
+
+    res.set("Cross-Origin-Resource-Policy", "cross-origin");
   } catch (error) {
     res.status(500).json({ error: "Error updating bio" });
   }

--- a/server/api/roommateProfile.js
+++ b/server/api/roommateProfile.js
@@ -431,13 +431,13 @@ router.put("/bio/:id", async (req, res) => {
       data: { bio: generatedBio },
     });
 
+    res.set("Cross-Origin-Resource-Policy", "cross-origin");
+
     res.status(200).json({
       message: "Bio updated successfully",
       bio: generatedBio,
       profile: updatedProfile,
     });
-
-    res.set("Cross-Origin-Resource-Policy", "cross-origin");
   } catch (error) {
     res.status(500).json({ error: "Error updating bio" });
   }


### PR DESCRIPTION
## Description

- Fixed bug on deployed application after implementing GenAI bio stretch goal where the cross origin resource policy was defaulted to same-origin.
- Set the cross origin resource policy to cross-origin.

## Milestones
This PR contributes to refining the stretch goal: users can update bio using genAI.

## Resources
No additional resources used.

## Test Plan
I tested that this change works by checking the response header in the network tab, and ensuring that the cross origin resource policy was set to cross-origin. 

<img width="542" height="703" alt="Screenshot 2025-07-24 at 5 09 59 PM" src="https://github.com/user-attachments/assets/98d7e368-8dc6-436f-a50b-c16248dd15f2" />

