### PR TITLE
fix: updated comment to reflect change from 100 km to 64 km radius

### DIFF
--- a/server/utils/matchingGroups.js
+++ b/server/utils/matchingGroups.js
@@ -283,7 +283,7 @@ function canAcceptNewMember(group, proposer, userMap) {
     return false;
   }
 
-  // check if any member of the group is more than 100 km away from the proposer
+  // check if any member of the group is more than 64 km (~40 miles) away from the proposer
   for (const member of group.members) {
     // validation for office coordinates to prevent errors
     if (


### PR DESCRIPTION
## Description

- Updates comment that explains location based filtering to use correct and updated restriction: 64 km instead of 100 km. 

## Milestones
This PR does not contribute to a specific milestone; rather, it cleans up the codebase. 

## Resources
No additional resources used.

## Test Plan
No test needed for updating comments. 
